### PR TITLE
PM5644: fix misalignment around green square

### DIFF
--- a/PM5644.svg
+++ b/PM5644.svg
@@ -128,7 +128,7 @@
 
 		<desc>centre cross-shaped grid with vertical middle line</desc>
 		<path
-			d="M50 60 L110 60 110.5 50.5 119.5 50.5 119.5 60 180 60 180 70 119.5 70 119.5 79.5 110.5 79.5 110.5 70 50 70Z"
+			d="M50 60 L110.5 60 110.5 50.5 119.5 50.5 119.5 60 180 60 180 70 119.5 70 119.5 79.5 110.5 79.5 110.5 70 50 70Z"
 			fill="url(#centergrid)"/>
 		<rect x="114.5" y="50.5" width="1" height="29" fill="#ffffff"/>
 


### PR DESCRIPTION
There's a small glitch around the central rectangle as it passes the green colour square:

![image](https://user-images.githubusercontent.com/194537/141677974-0b2ca2ef-c7ec-4023-ade5-1ab2419226ab.png)

This resolves it.

cheers,

Greg